### PR TITLE
Change date chaos-carnival event

### DIFF
--- a/app/client/src/components/Footer/index.tsx
+++ b/app/client/src/components/Footer/index.tsx
@@ -29,7 +29,7 @@ const Footer: React.FC = () => {
 						</LazyLoad>
 
 						<Typography className={classes.timeFont}>
-							January 8-9, 2021
+							February 10-11, 2021
 									</Typography>
 						<Hidden smDown>
 							<div className={classes.headerHomeDiv}>

--- a/app/client/src/components/Header/index.tsx
+++ b/app/client/src/components/Header/index.tsx
@@ -103,7 +103,7 @@ const MainHeader: React.FC<MainHeaderProps> = ({ inHomePage }) => {
 						</Hidden>
 						<div className={classes.headerDivCount}>
 							<CountDown
-								timeTillDate="01 08 2021, 6:00 am"
+								timeTillDate="02 10 2021, 6:00 am"
 								timeFormat="MM DD YYYY, h:mm a"
 								inHomePage={inHomePage}
 							/>

--- a/app/client/src/components/JoinCarnival/index.tsx
+++ b/app/client/src/components/JoinCarnival/index.tsx
@@ -55,16 +55,16 @@ const JoinCarnival = () => {
 				<hr className={classes.hrLine}></hr>
 				<div className={classes.dateDiv}>
 					<Typography className={classes.textDay}>
-						Day 1 - Friday
+						Day 1 - Wednesday
 					</Typography>
 					<Typography className={classes.textDate} style={{ marginBottom: '2rem' }}>
-						January 8th, 2021
+						February 10th, 2021
 					</Typography>
 					<Typography className={classes.textDay}>
-						Day 2 - Saturday
+						Day 2 - Thursday
 					</Typography>
 					<Typography className={classes.textDate} style={{ marginBottom: '2rem' }}>
-						January 9th, 2021
+						February 11th, 2021
 					</Typography>
 					<Typography className={classes.textDay} style={{ textAlign: "left", fontWeight: 700, marginBottom: '1rem' }}>
 						8AM-5PM EST

--- a/app/client/src/components/JoinCarnival/index.tsx
+++ b/app/client/src/components/JoinCarnival/index.tsx
@@ -75,7 +75,7 @@ const JoinCarnival = () => {
 						variant="outlined"
 						onClick={() => {
 							window.open(
-								"https://calendar.google.com/calendar/r/eventedit?text=Chaos+Carnival&dates=20210107T230000Z/20210109T030000Z&details=For+updates,+Join:+https://join.slack.com/t/chaoscarnival"
+								"https://calendar.google.com/calendar/r/eventedit?text=Chaos+Carnival&dates=20210209T230000Z/20210211T030000Z&details=For+updates,+Join:+https://join.slack.com/t/chaoscarnival"
 							);
 						}}
 					>

--- a/app/client/src/components/JoinCarnival/styles.ts
+++ b/app/client/src/components/JoinCarnival/styles.ts
@@ -120,7 +120,7 @@ export const useStyles = makeStyles((theme) => ({
 	},
 	textDate: {
 		fontWeight: 700,
-		fontSize: 30,
+		fontSize: 29,
 		marginBottom: 10,
 		textAlign: "left",
 		[theme.breakpoints.down("xs")]: {

--- a/app/client/src/components/JoinCarnival/timer.tsx
+++ b/app/client/src/components/JoinCarnival/timer.tsx
@@ -8,7 +8,7 @@ const Timer = () => {
 	const [now, setNow] = useState(moment());
 	const [over, setOver] = useState(false);
 
-	const then = moment("01 08 2021, 6:00 am", "MM DD YYYY, h:mm a");
+	const then = moment("02 10 2021, 6:00 am", "MM DD YYYY, h:mm a");
 	const days = then.diff(now, "days");
 	now.add(days, "days");
 	const hours = then.diff(now, "hours");

--- a/app/client/src/pages/HomePage/index.tsx
+++ b/app/client/src/pages/HomePage/index.tsx
@@ -53,7 +53,7 @@ function HomePage() {
 									className={classes.headerDesc}
 									style={{ margin: "auto" }}
 								>
-									January 8-9, 2021
+									February 10-11, 2021
 							</Typography>
 							</div>
 


### PR DESCRIPTION
Following change has been made with this pr - 

1 -  Change chaos carnival date on February 10-11, 2021
2 -  Days left counter change 
3 -  Week day name changed event day on Wednesday and Thursday
4 - Css for week day fixed

PTAL Attached screen shot - :

(a)
![Screenshot from 2020-11-19 19-51-47](https://user-images.githubusercontent.com/28762224/99681384-162d4200-2aa4-11eb-84c8-9c1b8218b2c4.png)

(b)
![Screenshot from 2020-11-19 19-52-12](https://user-images.githubusercontent.com/28762224/99681426-1f1e1380-2aa4-11eb-978a-b63782f24837.png)

(c)
![Screenshot from 2020-11-19 19-51-27](https://user-images.githubusercontent.com/28762224/99681444-26452180-2aa4-11eb-9ad4-12a8fcc910e3.png)

(d)
![Screenshot from 2020-11-19 19-51-40](https://user-images.githubusercontent.com/28762224/99681472-2c3b0280-2aa4-11eb-9bff-d2065c010447.png)












Signed-off-by: ashishjain <ashish.jain@mayadata.io>